### PR TITLE
Add Coinbase provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 TradeAssistant monitors markets, computes technical indicators, and generates daily analysis reports.
 
+The assistant can pull data from **yfinance**, **CSV files**, or the Coinbase API.
+
 ## Quick Start
 
 ```bash
@@ -9,3 +11,5 @@ pip install -e .
 cp config.toml.example config.toml
 python -m tradeassistant --run-once --config config.toml
 ```
+
+If you choose the `coinbase` provider set the `COINBASE_API_KEY` environment variable with your API token.

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,7 +1,9 @@
 [general]
 timezone = "Europe/Berlin"
-data_provider = "yfinance"
+data_provider = "yfinance" # or "coinbase" or "csv"
 symbols = ["AAPL", "MSFT", "BTC-USD", "ETH-USD"]
+
+# If using the Coinbase provider set COINBASE_API_KEY in the environment.
 
 [scheduler]
 hour_utc = 15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "APScheduler",
     "typer",
     "markdown",
+    "requests",
 ]
 
 [project.optional-dependencies]

--- a/src/tradeassistant/data.py
+++ b/src/tradeassistant/data.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
+
+import os
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Iterable
 
 import pandas as pd
+import requests
 import yfinance as yf
 
 CACHE = Path(".cache")
@@ -13,6 +16,9 @@ CACHE.mkdir(exist_ok=True)
 
 def _cache_path(symbol: str) -> Path:
     return CACHE / f"{symbol}.json"
+
+
+COINBASE_API = "https://api.exchange.coinbase.com"
 
 
 def fetch_yfinance(symbol: str) -> pd.DataFrame:
@@ -31,6 +37,43 @@ def fetch_yfinance(symbol: str) -> pd.DataFrame:
         raise RuntimeError(f"failed to download data for {symbol}")
     df = df.rename(columns=str.lower)
     df.index = df.index.tz_localize("UTC")
+    _cache_path(symbol).write_text(df.to_json())
+    return df
+
+
+def fetch_coinbase(symbol: str) -> pd.DataFrame:
+    end = datetime.now(tz=timezone.utc)
+    start = end - timedelta(days=180)
+    params = {
+        "start": start.isoformat(),
+        "end": end.isoformat(),
+        "granularity": 86400,
+    }
+    headers = {}
+    token = os.getenv("COINBASE_API_KEY")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    url = f"{COINBASE_API}/products/{symbol}/candles"
+    retries = 3
+    data = None
+    for _ in range(retries):
+        try:
+            resp = requests.get(url, params=params, headers=headers, timeout=10)
+            if resp.status_code == 200:
+                data = resp.json()
+                if data:
+                    break
+        except Exception:
+            time.sleep(1)
+    else:
+        raise RuntimeError(f"failed to download data for {symbol} from Coinbase")
+    df = pd.DataFrame(
+        data,
+        columns=["time", "low", "high", "open", "close", "volume"],
+    )
+    df["time"] = pd.to_datetime(df["time"], unit="s", utc=True)
+    df = df.set_index("time")
+    df = df.rename(columns=str.lower).sort_index()
     _cache_path(symbol).write_text(df.to_json())
     return df
 
@@ -59,6 +102,11 @@ def load_data(symbols: Iterable[str], provider: str = "yfinance") -> dict[str, p
         if provider == "yfinance":
             try:
                 df = fetch_yfinance(sym)
+            except Exception:
+                df = load_cached(sym)
+        elif provider == "coinbase":
+            try:
+                df = fetch_coinbase(sym)
             except Exception:
                 df = load_cached(sym)
         elif provider == "csv":

--- a/tests/test_coinbase.py
+++ b/tests/test_coinbase.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import requests
+from tradeassistant.data import fetch_coinbase
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+        self.status_code = 200
+    def json(self):
+        return self._data
+    def raise_for_status(self):
+        pass
+
+def test_fetch_coinbase(monkeypatch):
+    sample = [
+        [1622505600, 100, 110, 105, 108, 123.0],
+        [1622592000, 108, 115, 110, 111, 321.0],
+    ]
+    def fake_get(url, params=None, headers=None, timeout=10):
+        return DummyResp(sample)
+    monkeypatch.setattr(requests, "get", fake_get)
+    df = fetch_coinbase("BTC-USD")
+    assert list(df.columns) == ["low", "high", "open", "close", "volume"]
+    assert len(df) == 2


### PR DESCRIPTION
## Summary
- enable Coinbase data fetching in `tradeassistant.data`
- document Coinbase provider usage in README and example config
- depend on `requests` for API access
- include a unit test for the new Coinbase provider

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686d510231888332bf018fcf5f1f1c4e