### PR TITLE
Add Coinbase price bot

### DIFF
--- a/src/tradeassistant/__init__.py
+++ b/src/tradeassistant/__init__.py
@@ -1,1 +1,3 @@
+from .__main__ import cli
+
 __all__ = ["cli"]

--- a/src/tradeassistant/__main__.py
+++ b/src/tradeassistant/__main__.py
@@ -11,7 +11,10 @@ from .data import load_data
 from .report import save_markdown, to_markdown
 from .storage import init_db, insert_ohlcv, insert_report
 
+from .pricebot import run as run_pricebot
+
 app = typer.Typer()
+cli = app
 
 
 @app.command()
@@ -47,6 +50,15 @@ def main(config: Path = typer.Option(Path("config.toml"), "--config"), run_once:
             typer.echo("Exiting")
     else:
         typer.echo("Specify --run-once or --daemon")
+
+
+@app.command()
+def pricebot(interval: int = 300, symbol: str = "BTC-USD") -> None:
+    """Print current price and change every few minutes."""
+    try:
+        run_pricebot(interval=interval, symbol=symbol)
+    except KeyboardInterrupt:
+        typer.echo("Exiting")
 
 
 if __name__ == "__main__":

--- a/src/tradeassistant/pricebot.py
+++ b/src/tradeassistant/pricebot.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+import requests
+
+COINBASE_API = "https://api.exchange.coinbase.com"
+
+
+def fetch_price(symbol: str = "BTC-USD") -> float:
+    """Fetch the latest trade price for the given symbol."""
+    url = f"{COINBASE_API}/products/{symbol}/ticker"
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    return float(data["price"])
+
+
+def run(interval: int = 300, symbol: str = "BTC-USD") -> None:
+    """Continuously print the price and change every ``interval`` seconds."""
+    last_price: Optional[float] = None
+    while True:
+        price = fetch_price(symbol)
+        change = 0.0 if last_price is None else price - last_price
+        print(f"{symbol} price: {price:.2f} (change {change:+.2f})")
+        last_price = price
+        time.sleep(interval)


### PR DESCRIPTION
## Summary
- implement simple price bot using Coinbase API
- expose CLI via `cli` variable
- add `pricebot` command to send BTC-USD price every 5 minutes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686d9854a93c833285d491419a54396f